### PR TITLE
alternative connection to peripheral with identifier and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,23 @@ Note that the callback closure can be called multiple times, but always start an
 
 ### Connecting to a peripheral
 ```swift
-peripheral.connect { (error) in 
-    if let error = error {
+peripheral.connect { (result) in 
+    switch result {
+    case .faliure(let error):
         // an error happened during the connection or the connect call timed out
+    case .success(let peripheral):
+        // the connection was successful
     }
 }
 ```
 ### Disconnecting from a peripheral
 ```swift
-peripheral.disconnect { (error) in 
-    if let error = error {
+peripheral.disconnect { (result) in 
+    switch result {
+    case .faliure(let error):
         // an error happened during the disconnection, but your peripheral is guaranteed to be disconnected 
+    case .success(let peripheral):
+        // the disconnection completed without error
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ SwiftyBluetooth.scanForPeripherals(withServiceUUIDs: nil, timeoutAfter: 15) { sc
 Note that the callback closure can be called multiple times, but always start and finish with a callback containing a `.scanStarted` and `.scanStopped` result respectively. Your callback will be called with a `.scanResult` for every unique peripheral found during the scan.  
 
 ### Connecting to a peripheral
+If you already have a reference to the peripheral you would like to connect to, you can do so like this:
+
 ```swift
 peripheral.connect { (result) in 
     switch result {
@@ -57,6 +59,18 @@ peripheral.connect { (result) in
         // the connection was successful
     }
 }
+```
+However, if you are trying to connect to your peripheral from a previous saved identifier and set of services this can be done like this:
+
+```swift
+central.connect(peripheralUUID: identifier, serviceUUIDs: serviceIdentifiers, completion: { (result) in
+    switch result {
+    case .faliure(let error):
+        // an error happened during the connection or the connect call timed out
+    case .success(let peripheral):
+        // the connection was successful
+    }
+})
 ```
 ### Disconnecting from a peripheral
 ```swift

--- a/SwiftyBluetooth/Source/Central.swift
+++ b/SwiftyBluetooth/Source/Central.swift
@@ -119,6 +119,14 @@ extension Central {
         centralProxy.connect(peripheral: peripheral, timeout: timeout, completion)
     }
     
+    func connect(peripheralUUID: UUID,
+                 serviceUUIDs: [CBUUID],
+                 timeout: TimeInterval = 10,
+                 completion: @escaping ConnectPeripheralCallback)
+    {
+        centralProxy.connect(peripheralUUID: peripheralUUID, serviceUUIDs: serviceUUIDs, timeout: timeout, completion)
+    }
+    
     func disconnect(peripheral: CBPeripheral,
                     timeout: TimeInterval = 10,
                     completion: @escaping DisconnectPeripheralCallback)

--- a/SwiftyBluetooth/Source/Central.swift
+++ b/SwiftyBluetooth/Source/Central.swift
@@ -62,6 +62,18 @@ public enum PeripheralScanResult {
 }
 
 /**
+ The different results returned in the closure of the Central connect(...) and disconnect(...) functions.
+ 
+ - Success: The connection or disconnection was successful.
+ - Error: The connection or disconnection failed with a given error.
+ 
+ */
+public enum PeripheralConnectionResult {
+    case success(peripheral: Peripheral)
+    case failed(error: Error?)
+}
+
+/**
     An enum type whoses rawValues mirror the CBCentralManagerState enum owns Integer values but without the ".Resetting" and ".Unknown" temporary values.
 
     - Unsupported: CBCentralManagerState.Unsupported
@@ -80,8 +92,8 @@ public enum AsyncCentralState: Int {
 public typealias AsyncCentralStateCallback = (AsyncCentralState) -> Void
 public typealias BluetoothStateCallback = (CBCentralManagerState) -> Void
 public typealias PeripheralScanCallback = (PeripheralScanResult) -> Void
-public typealias ConnectPeripheralCallback = (Error?) -> Void
-public typealias DisconnectPeripheralCallback = (Error?) -> Void
+public typealias ConnectPeripheralCallback = (PeripheralConnectionResult) -> Void
+public typealias DisconnectPeripheralCallback = (PeripheralConnectionResult) -> Void
 
 /// A singleton wrapping a CBCentralManager instance to run CBCentralManager related functions with closures based callbacks instead of the usual CBCentralManagerDelegate interface.
 public final class Central {

--- a/SwiftyBluetooth/Source/Central.swift
+++ b/SwiftyBluetooth/Source/Central.swift
@@ -70,7 +70,7 @@ public enum PeripheralScanResult {
  */
 public enum PeripheralConnectionResult {
     case success(peripheral: Peripheral)
-    case failed(error: Error?)
+    case failed(error: SBError?)
 }
 
 /**

--- a/SwiftyBluetooth/Source/Central.swift
+++ b/SwiftyBluetooth/Source/Central.swift
@@ -119,14 +119,6 @@ extension Central {
         centralProxy.connect(peripheral: peripheral, timeout: timeout, completion)
     }
     
-    func connect(peripheralUUID: UUID,
-                 serviceUUIDs: [CBUUID],
-                 timeout: TimeInterval = 10,
-                 completion: @escaping ConnectPeripheralCallback)
-    {
-        centralProxy.connect(peripheralUUID: peripheralUUID, serviceUUIDs: serviceUUIDs, timeout: timeout, completion)
-    }
-    
     func disconnect(peripheral: CBPeripheral,
                     timeout: TimeInterval = 10,
                     completion: @escaping DisconnectPeripheralCallback)
@@ -162,6 +154,20 @@ extension Central {
     /// The underlying CBCentralManager isScanning value
     public var isScanning: Bool {
         return self.centralProxy.centralManager.isScanning
+    }
+    
+    /// Alternative connection method, when identifier and services are known for a peripheral.
+    ///
+    /// - Parameter peripheralUUID: The unique identifier (UUID) for the given peripheral.
+    /// - Parameter serviceUUIDs: The service UUIDs to for the given peripheral.
+    /// - Parameter timeout: The time in seconds before the connection attempt is stopped and the completion closure is called with a failed result.
+    /// - Parameter completion: The closures, called upon completion (succesful or otherwise) of the connection.
+    public func connect(peripheralUUID: UUID,
+                 serviceUUIDs: [CBUUID],
+                 timeout: TimeInterval = 10,
+                 completion: @escaping ConnectPeripheralCallback)
+    {
+        centralProxy.connect(peripheralUUID: peripheralUUID, serviceUUIDs: serviceUUIDs, timeout: timeout, completion)
     }
     
     /// Scans for Peripherals through a CBCentralManager scanForPeripheralsWithServices(...) function call.

--- a/SwiftyBluetooth/Source/PeripheralProxy.swift
+++ b/SwiftyBluetooth/Source/PeripheralProxy.swift
@@ -85,7 +85,7 @@ extension PeripheralProxy {
         if self.valid {
             Central.sharedInstance.connect(peripheral: self.cbPeripheral, completion: completion)
         } else {
-            completion(SBError.invalidPeripheral)
+            completion(.failed(error: SBError.invalidPeripheral))
         }
     }
     
@@ -105,10 +105,13 @@ private final class ReadRSSIRequest {
 
 extension PeripheralProxy {
     func readRSSI(_ completion: @escaping ReadRSSIRequestCallback) {
-        self.connect { (error) in
-            if let error = error {
+        self.connect { (result) in
+            switch result {
+            case .failed(let error):
                 completion(nil, error)
                 return
+            default:
+                break
             }
             
             let request = ReadRSSIRequest(callback: completion)
@@ -173,10 +176,13 @@ private final class ServiceRequest {
 
 extension PeripheralProxy {
     func discoverServices(_ serviceUUIDs: [CBUUID]?, completion: @escaping ServiceRequestCallback) {
-        self.connect { (error) in
-            if let error = error {
+        self.connect { (result) in
+            switch result {
+            case .failed(let error):
                 completion(nil, error)
                 return
+            default:
+                break
             }
             
             // Checking if the peripheral has already discovered the services requested

--- a/SwiftyBluetooth/Source/PeripheralProxy.swift
+++ b/SwiftyBluetooth/Source/PeripheralProxy.swift
@@ -110,7 +110,7 @@ extension PeripheralProxy {
             case .failed(let error):
                 completion(nil, error)
                 return
-            default:
+            case .success(_):
                 break
             }
             
@@ -181,7 +181,7 @@ extension PeripheralProxy {
             case .failed(let error):
                 completion(nil, error)
                 return
-            default:
+            case .success(_):
                 break
             }
             

--- a/SwiftyBluetooth/Source/SBError.swift
+++ b/SwiftyBluetooth/Source/SBError.swift
@@ -50,7 +50,9 @@ public enum SBError: Error {
     case scanningEndedUnexpectedly
     case operationTimedOut(operation: SBOperation)
     case invalidPeripheral
+    case peripheralFailedToConnectWithError(error: Error)
     case peripheralFailedToConnectReasonUnknown
+    case peripheralFailedToDisconnectWithError(error: Error)
     case peripheralServiceNotFound(missingServicesUUIDs: [CBUUID])
     case peripheralCharacteristicNotFound(missingCharacteristicsUUIDs: [CBUUID])
     case peripheralDescriptorsNotFound(missingDescriptorsUUIDs: [CBUUID])
@@ -68,8 +70,12 @@ extension SBError: LocalizedError {
             return "Bluetooth operation timed out: \(operation.rawValue)"
         case .invalidPeripheral:
             return "Invalid Bluetooth peripheral, you must rediscover this peripheral to use it again."
+        case .peripheralFailedToConnectWithError(let error):
+            return "Failed to connect to your peripheral, \(error.localizedDescription)"
         case .peripheralFailedToConnectReasonUnknown:
             return "Failed to connect to your peripheral for an unknown reason."
+        case .peripheralFailedToDisconnectWithError(let error):
+            return "Failed to disconnect from your peripheral, \(error.localizedDescription)"
         case .peripheralServiceNotFound(let missingUUIDs):
             let missingUUIDsString = missingUUIDs.map { $0.uuidString }.joined(separator: ",")
             return "Peripheral service(s) not found: \(missingUUIDsString)"


### PR DESCRIPTION
I was looking for a way to connect to a SwiftyBluetooth Peripheral given its UUID and service identifiers, and it didn't seem like this was currently possible. This is important for times where one is storing the UUID of the peripheral for faster reconnection at a later time. Thoughts @tehjord ?