### PR TITLE
scanning should throw error on timeout, allows for distinguishing bet…

### DIFF
--- a/SwiftyBluetooth/Source/CentralProxy.swift
+++ b/SwiftyBluetooth/Source/CentralProxy.swift
@@ -144,7 +144,7 @@ extension CentralProxy {
         let weakRequest = timer.userInfo as! Weak<PeripheralScanRequest>
         
         if weakRequest.value != nil {
-            self.stopScan()
+            self.stopScan(error: SBError.operationTimedOut(operation: .scanForPeripherals))
         }
     }
 }

--- a/SwiftyBluetooth/Source/SBError.swift
+++ b/SwiftyBluetooth/Source/SBError.swift
@@ -32,6 +32,7 @@ public enum SBError: Error {
     }
     
     public enum SBOperation: String {
+        case scanForPeripherals = "Scan for peripherals"
         case connectPeripheral = "Connect peripheral"
         case disconnectPeripheral = "Disconnect peripheral"
         case readRSSI = "Read RSSI"


### PR DESCRIPTION
…ween a user stopping scanning upon successful discovery and a timeout in the case of no peripherals being found