### PR TITLE
skip stop scan if bluetooth is powered down or unsupported

### DIFF
--- a/SwiftyBluetooth/Source/CentralProxy.swift
+++ b/SwiftyBluetooth/Source/CentralProxy.swift
@@ -134,7 +134,12 @@ extension CentralProxy {
     }
     
     func stopScan(error: SBError? = nil) {
-        self.centralManager.stopScan()
+
+        // avoid an API MISUSE warning on the console if bluetooth is powered off or unsupported
+        if self.centralManager.state != .poweredOff, self.centralManager.state != .unsupported {
+            self.centralManager.stopScan()
+        }
+
         if let scanRequest = self.scanRequest {
             self.scanRequest = nil
             scanRequest.callback(.scanStopped(error: error))


### PR DESCRIPTION
This PR addresses issue #29 